### PR TITLE
ci(dependencies): fix ci by pinning python version

### DIFF
--- a/conda/dev.yaml
+++ b/conda/dev.yaml
@@ -3,7 +3,7 @@ channels:
   - nodefaults
   - conda-forge
 dependencies:
-  - python >=3.8.1
+  - python >=3.8.1, <=3.11.5
   - pip
   - poetry
   - nodejs  # used by semantic-release


### PR DESCRIPTION
Resolves #1  
## Pull Request description
<!-- Describe the purpose of your PR and the changes you have made. -->
We have investigated the issue with the ci, and have found that the dependencies were failing to install because the conda environment file (`conda/dev.yaml`) pinned just the minimum python version (>=3.8.1) which caused conda to install python 3.12 causing dependencies issues (mainly numpy 1.25.2 which only supports python 3.9 to 3.11).

<!-- Which issue this PR aims to resolve or fix? E.g.:
Solve #004
-->

## How to test these changes

<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->

* ```...```

<!-- Modify the options to suit your project. -->
## Pull Request checklists

This PR is a:
- [ ] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:
- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.


Author's checklist:
- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more complexity.
- [ ] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
